### PR TITLE
Trip information for all routes at a given stop

### DIFF
--- a/lib/octranspo_fetch.rb
+++ b/lib/octranspo_fetch.rb
@@ -48,7 +48,7 @@ class OCTranspo
     #       one day.
     #
     def get_route_summary_for_stop(stop, options={})
-        max_cache_time = (options[:max_cache_time] or 60*5)
+        max_cache_time = (options[:max_cache_time] or 60*60*24)
         cached_result = @route_summary_cache[stop]
         if !cached_result.nil? and ((cached_result[:time] + max_cache_time) > Time.now.to_i)
             @cache_hits += 1

--- a/octranspo_fetch.gemspec
+++ b/octranspo_fetch.gemspec
@@ -1,10 +1,10 @@
 Gem::Specification.new do |s|
   s.name        = 'octranspo_fetch'
-  s.version     = '0.0.4'
-  s.date        = '2013-09-24'
+  s.version     = '0.0.5'
+  s.date        = '2016-09-05'
   s.summary     = "Fetch data from OC Tranpo API"
   s.description = "A simple wrapper around the OC Transpo API with some minimal caching."
-  s.authors     = ["Jason Walton"]
+  s.authors     = ["Jason Walton", "Kevin Ross"]
   s.files       = ["lib/octranspo_fetch.rb"]
   s.homepage    =
     'http://rubygems.org/gems/octranspo_fetch'


### PR DESCRIPTION
I haven't seen the documentation for v1.1 of the API but v1.2 supports querying for trips for all routes at a given stop rather than just one route at a time. I've updated the fetch function to pull from v1.2 and added support to get_next_trips_for_stop for getting all routes.
