### PR TITLE
updating api endpoint

### DIFF
--- a/lib/octranspo_fetch.rb
+++ b/lib/octranspo_fetch.rb
@@ -238,7 +238,7 @@ class OCTranspo
 
     private
 
-    BASE_URL = "https://api.octranspo1.com/v1.2"
+    BASE_URL = "https://api.octranspo1.com/v1.3"
     OCT_NS = {'oct' => 'http://octranspo.com', 't' => 'http://tempuri.org/'}
     NEXT_TRIPS_CACHE_SIZE = 100
     ROUTE_CACHE_SIZE = 100


### PR DESCRIPTION
API Version 1.2 was deprecated, I have replaced the reference to `1.2` with `1.3`.

```
Version 1.2 Deprecation
Version 1.2 of the OC Transpo Live Next Bus Arrival Data Feed API will be deprecated at 11:59 pm on November 18, 2019. Please move your applications to version 1.3 to prevent any loss of functionality.
```
https://www.octranspo.com/en/plan-your-trip/travel-tools/developers/dev-doc/